### PR TITLE
Pin browser_action icon to nav bar

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,6 +25,7 @@
   },
 
   "browser_action": {
+    "default_area": "navbar",
     "default_icon": "icons/logo.svg",
     "default_title": "MoSo",
     "default_popup": "popup/main.html"


### PR DESCRIPTION
This PR adds a line to `manifest.json` to force the browser action icon to appear in the nav bar by default when the extension installed or run locally. 