### PR TITLE
Fix context menu share

### DIFF
--- a/src/background/contextmenus.js
+++ b/src/background/contextmenus.js
@@ -42,6 +42,7 @@ export class ContextMenus extends Component {
             this.sendMessage('shareURL', info.linkUrl);
             break;
         }
+        browser.browserAction.openPopup();
       });
 
       browser.menus.onShown.addListener(async (info, tab) => {

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -123,7 +123,7 @@ class Main {
 
     for (const observer of this.#observers) {
       try {
-        const result = await observer.handleEvent(type, data);
+        const result = observer.handleEvent(type, data);
         if (result !== undefined) {
           returnValues.push(result);
         }

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -123,7 +123,7 @@ class Main {
 
     for (const observer of this.#observers) {
       try {
-        const result = observer.handleEvent(type, data);
+        const result = await observer.handleEvent(type, data);
         if (result !== undefined) {
           returnValues.push(result);
         }

--- a/src/background/ui.js
+++ b/src/background/ui.js
@@ -126,13 +126,13 @@ export class UI extends Component {
       }
 
       case "shareURL":
-        return this.#sendOrQueueAndPopup({
+        return this.#sendOrQueue({
           type: "share",
           url: data,
         });
 
       case 'postResult':
-        return this.#sendOrQueueAndPopup({
+        return this.#sendOrQueue({
           type: "postResult",
           url: data,
         });
@@ -142,14 +142,14 @@ export class UI extends Component {
           active: true,
           windowId: this.#currentWindowId
         });
-        return this.#sendOrQueueAndPopup({
+        return this.#sendOrQueue({
           type: "share",
           url: tabs.length && (tabs[0].url.startsWith('http://') || tabs[0].url.startsWith('https://')) ? tabs[0].url : '',
         });
       }
 
       case 'replyStatus':
-        return this.#sendOrQueueAndPopup({
+        return this.#sendOrQueue({
           type: "share",
           status: data
         });
@@ -208,11 +208,10 @@ export class UI extends Component {
     }
   }
 
-  async #sendOrQueueAndPopup(msg) {
+  async #sendOrQueue(msg) {
     if (this.#currentPort) {
       return this.#currentPort.postMessage(msg);
     }
     this.#messageQueue.push(msg);
-    await browser.browserAction.openPopup();
   }
 }

--- a/src/background/ui.js
+++ b/src/background/ui.js
@@ -92,7 +92,10 @@ export class UI extends Component {
 
     await this.#sendDataToCurrentPort();
 
-    // Sending the pending messages.
+    // Show timeline by default if no other event/action queued (user manually opens popup via browser button)
+    if (!this.#messageQueue.length) this.sendMessage("fetchTimeline")
+
+    // ...otherwise, send pending messages.
     while (this.#messageQueue.length && this.#currentPort) {
       await this.#currentPort.postMessage(this.#messageQueue.splice(0, 1)[0]);
     }

--- a/src/popup/views/main.js
+++ b/src/popup/views/main.js
@@ -10,9 +10,7 @@ customElements.define('view-main', class ViewMain extends ViewBase {
   connectedCallback() {
     super.connectedCallback();
 
-    // In case the panel was opened by the user, let's fetch the timeline to
-    // trigger the `timeline` view.
-    this.sendMessage("fetchTimeline");
+    // trigger background services:
     this.sendMessage("urlShareable");
     this.sendMessage("detectActors");
 


### PR DESCRIPTION
The share functionality was broken for 2 reasons:

1. sending the timeline message by default every time "overwrites" the intent for the popup to display the share view.

2. the event queue is async, but reacting to a user gesture needs to be synchronous - I was receiving the following error:
```
Uncaught (in promise) Error: openPopup requires a user gesture undefined
    stateChanged moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/ui.js:67
    AsyncFunctionThrow self-hosted:856
    (Async: async)
    setState moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/main.js:102
    setState moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/component.js:28
    #connectToHost moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/masto.js:101
    AsyncFunctionThrow self-hosted:856
    (Async: async)
    handleEvent moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/masto.js:248
    handleEvent moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/main.js:130
    InterpretGeneratorResume self-hosted:1465
    AsyncFunctionNext self-hosted:852
    (Async: async)
    sendMessage moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/component.js:33
    panelConnected moz-extension://8dd085c1-5ef0-49a7-8d25-7c7324fff8c6/background/ui.js:85
    apply self-hosted:2337
    applySafeWithoutClone resource://gre/modules/ExtensionCommon.sys.mjs:677
    asyncWithoutClone resource://gre/modules/ExtensionCommon.sys.mjs:2828
```